### PR TITLE
Revert "build(deps): bump asset-pipeline-grails from 2.15.1 to 3.4.5 in /bigbluebutton-web"

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   //--- BigBlueButton Dependencies End
   console "org.grails:grails-console"
   profile "org.grails.profiles:web"
-  runtime "com.bertramlabs.plugins:asset-pipeline-grails:3.4.5"
+  runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.15.1"
   testCompile "org.grails:grails-gorm-testing-support"
   testCompile "org.grails.plugins:geb"
   testCompile "org.grails:grails-web-testing-support"


### PR DESCRIPTION
Reverts zhem0004/bigbluebutton#11

The project could not resolve this update